### PR TITLE
Remove share method

### DIFF
--- a/src/ServiceProviderLaravel5.php
+++ b/src/ServiceProviderLaravel5.php
@@ -26,7 +26,7 @@ class ServiceProviderLaravel5 extends \Illuminate\Support\ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/config/config.php', 'slack');
 
-        $this->app['maknz.slack'] = $this->app->share(function ($app) {
+        $this->app['maknz.slack'] = $this->app->singleton('slack', function ($app) {
             return new Client(
                 $app['config']->get('slack.endpoint'),
                 [


### PR DESCRIPTION
The share method has been remove in Laravel 5.4 and the singleton method should be used instead.